### PR TITLE
Removing hidden submission comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ If you are unsure if something is actually unfinished just submit an [issue](htt
 
 ### Books
 
-[SUBMITTED]: # (2022-02-02 - @Zorziel)
 - [Der Process (The Trial)](https://en.wikipedia.org/wiki/The_Trial) *by [Franz Kafka](https://en.wikipedia.org/wiki/Franz_Kafka)* - The terrifying tale of Josef K., a respectable bank officer who is suddenly and inexplicably arrested and must defend himself against a charge about which he can get no information.  ![Reason](https://img.shields.io/badge/Reason-Death%20of%20Author-brown?style=plastic)
 
 
@@ -38,16 +37,12 @@ If you are unsure if something is actually unfinished just submit an [issue](htt
 
 ### TV Shows
 
-[SUBMITTED]: # (2022-01-30 - @Zorziel)
 - [Dark Matter](https://www.imdb.com/title/tt4159076) (2015-2017) **[7.5]** - Six people wake up on a spaceship with no memory of who they are or their past, only to learn that they're the most wanted and dangerous assassins in the galaxy. This show also had one of the best android characters in the aughts television. ![reason](https://img.shields.io/badge/Reason-Show%20Cancelled-red.svg?style=plastic) ![reason](https://img.shields.io/badge/Reason-Assets%20Sold-purple.svg?style=plastic) 
 
-[SUBMITTED]: # (2022-01-30 - @Zorziel)
 - [Dirk Gently's Holistic Detective Agency](https://www.imdb.com/title/tt4047038/) (2016-2017) **[8.2]** - This Elijah Wood-lead take on the Douglas Adams novel series was quirky, fun, engaging, and only got better with each new episode.  ![reason](https://img.shields.io/badge/Reason-Lost%20Popularity-blue.svg?style=plastic)
 
-[SUBMITTED]: # (2022-01-30 - @Zorziel)
 - [Firefly](https://www.imdb.com/title/tt0303461/) (2002-2003) **[9.0]** - Gripping, clever, fun space western that still holds up today, regardless of Joss Whedon's involvement. ![reason](https://img.shields.io/badge/Reason-Production%20Error-orange.svg?style=plastic)  
 
-[SUBMITTED]: # (2022-01-30 - @Zorziel)
 - [The Order](https://www.imdb.com/title/tt8295472) (2019-2020) **[6.8]** - Brighter, more action-oriented, and better acted than The Magicians, this "magic is real" show also has warewolves.  ![reason](https://img.shields.io/badge/Reason-Show%20Cancelled-red.svg?style=plastic) 
 
 


### PR DESCRIPTION
The submission tracking as comments is redundant so there is a git history of all commits.  In addition, #1 references allowing multiple user comments and reviews if that's wanted.